### PR TITLE
Feature/sampling rate setter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ ENV/
 
 # IDE settings
 .vscode/
+private/Haiopy_whatever.py

--- a/haiopy/buffers.py
+++ b/haiopy/buffers.py
@@ -2,6 +2,7 @@ import numpy as np
 import pyfar as pf
 from abc import abstractmethod
 from threading import Event
+import warnings
 
 
 class _Buffer(object):
@@ -185,6 +186,15 @@ class SignalBuffer(_Buffer):
         """The sampling rate of the underlying data."""
         return self.data.sampling_rate
 
+    @sampling_rate.setter
+    def sampling_rate(self, sampling_rate):
+        """Set new sampling_rate and resample the input Signal"""
+        self.check_if_active()
+        self._data = pf.dsp.resample(self._data, sampling_rate)
+        warnings.warn("Resampling the input Signal to sampling_rate="
+                      f"{sampling_rate} might generate artifacts.")
+        self._update_data()
+
     @property
     def n_blocks(self):
         """The number of blocks contained in the buffer."""
@@ -222,6 +232,7 @@ class SignalBuffer(_Buffer):
         self._strided_data = np.lib.stride_tricks.as_strided(
             self.data.time,
             (*self.data.cshape, self.n_blocks, self.block_size))
+        self._index = 0
 
     def next(self):
         """Return the next audio block as numpy array and increment the block

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -208,3 +208,20 @@ def test_signal_buffer_updates():
 
     with pytest.raises(BufferError, match="needs to be inactive"):
         buffer.data
+
+
+def test_sampling_rate_setter():
+    # Test setting the sampling rate, resampling the Signal and updating data
+    block_size = 512
+    sampling_rate = 44100
+    sine = pf.signals.sine(440, 4*block_size, sampling_rate=sampling_rate)
+    buffer = SignalBuffer(block_size, sine)
+    assert buffer.sampling_rate == 44100
+
+    new_sampling_rate = sampling_rate*2
+    with pytest.warns(UserWarning, match="Resampling the input Signal"):
+        buffer.sampling_rate = new_sampling_rate
+    resampled_sig = pf.dsp.resample(sine, new_sampling_rate)
+    assert buffer.sampling_rate == 88200
+    assert buffer.n_blocks == 8
+    assert buffer.data == resampled_sig


### PR DESCRIPTION
Implemented setter for sampling_rate using `pyfar.dsp.resample`. Setting the buffer sampling_rate will also raise a warning. 