### PR TITLE
Add missing n_channels to buffers

### DIFF
--- a/haiopy/buffers.py
+++ b/haiopy/buffers.py
@@ -53,6 +53,12 @@ class _Buffer(object):
         """Return sampling rate."""
         pass
 
+    @property
+    @abstractmethod
+    def n_channels(self):
+        """Return number of channels."""
+        raise NotImplementedError()
+
     def __iter__(self):
         return self
 
@@ -343,6 +349,11 @@ class SineGenerator(_Buffer):
         self._phase = 0
 
     @property
+    def n_channels(self):
+        """Return the number of channels. This is currently always 1."""
+        return 1
+
+    @property
     def phase(self):
         """Return the current phase of the sinewave"""
         return self._phase
@@ -429,6 +440,11 @@ class NoiseGenerator(_Buffer):
     def sampling_rate(self, sampling_rate):
         self.check_if_active()
         self._sampling_rate = sampling_rate
+
+    @property
+    def n_channels(self):
+        """Return the number of channels. This is currently always 1."""
+        return 1
 
     @property
     def spectrum(self):

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -229,6 +229,8 @@ def test_SineGenerator():
     assert sine.sampling_rate == sampling_rate
     assert sine.phase == 0
 
+    assert sine.n_channels == 1
+
     # check if sine generator is not active yet
     assert sine.is_active is False
 
@@ -326,6 +328,8 @@ def test_NoiseGenerator():
     assert noise.rms == 1
     assert noise.sampling_rate == 44100
     assert noise.seed == 10
+
+    assert noise.n_channels == 1
 
     # check if noise generator is not active yet
     assert noise.is_active is False


### PR DESCRIPTION
The property is required by devices to check if the number of buffer elements matches the selected output channels.
In _Buffer, this is an abstract property, which needs to be specified in child classes.
Sine and Noise generators currently only support a single channel.